### PR TITLE
Enable UNet segmentation to use pretrained SMP encoders

### DIFF
--- a/configs/seg/experiment.yaml
+++ b/configs/seg/experiment.yaml
@@ -18,7 +18,7 @@ data:
   few_shot_k: null
   few_shot_seed: null
 model:
-  name: fcn # upernet
+  name: fcn # upernet or unet
   backbone: sat_mae
   backbone_type: ""
   feature_map_indices: [5, 11, 17, 23]
@@ -44,6 +44,14 @@ model:
   loss_on_all_patches: True
   only_scaler_trainable: False
   only_bias_trainable: False
+  # U-Net specific options. Setting `unet_encoder_name` enables using
+  # segmentation-models-pytorch with pretrained backbones such as 'resnet34'.
+  unet_bilinear: True
+  unet_encoder_name: null
+  unet_encoder_weights: imagenet
+  unet_encoder_depth: 5
+  unet_decoder_channels: null
+  unet_decoder_use_batchnorm: True
 knn:
   knn_eval: False
   knn_k: 5

--- a/main_segmentation.py
+++ b/main_segmentation.py
@@ -37,6 +37,23 @@ def main(cfg):
         pretrain_args = src.utils.get_config_from_mlflow_run(config)
         src.utils.assert_model_compatibility(pretrain_args, config, ignore=["model"])
 
+    unet_kwargs = {}
+    if config.model.name == "unet":
+        unet_kwargs = {
+            "unet_bilinear": getattr(config.model, "unet_bilinear", True),
+            "unet_encoder_name": getattr(config.model, "unet_encoder_name", None),
+            "unet_encoder_weights": getattr(
+                config.model, "unet_encoder_weights", "imagenet"
+            ),
+            "unet_encoder_depth": getattr(config.model, "unet_encoder_depth", 5),
+            "unet_decoder_channels": getattr(
+                config.model, "unet_decoder_channels", None
+            ),
+            "unet_decoder_use_batchnorm": getattr(
+                config.model, "unet_decoder_use_batchnorm", True
+            ),
+        }
+
     task = src.trainers.segmentation.SegmentationTrainer(
         segmentation_model=config.model.name,
         model=config.model.backbone,
@@ -71,6 +88,7 @@ def main(cfg):
         only_bias_trainable=config.model.only_bias_trainable,
         only_scaler_trainable=config.model.only_scaler_trainable,
         class_names=config.data.class_names,
+        **unet_kwargs,
     )
 
     accelerator = "gpu" if torch.cuda.is_available() else "cpu"

--- a/src/models_segmentation.py
+++ b/src/models_segmentation.py
@@ -10,6 +10,12 @@ import torch
 import torch.nn.functional as F
 
 
+try:
+    import segmentation_models_pytorch as smp
+except ImportError:  # pragma: no cover - optional dependency
+    smp = None
+
+
 def _build_norm_layer(num_features: int, norm_cfg: Optional[dict]):
     """Create a normalization layer from a configuration dictionary."""
 
@@ -52,6 +58,115 @@ class _ConvBNAct(torch.nn.Sequential):
             layers.append(norm_layer)
         layers.append(torch.nn.ReLU(inplace=True))
         super().__init__(*layers)
+
+
+class _DoubleConv(torch.nn.Module):
+    """Two successive convolution blocks used by the U-Net architecture."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        mid_channels: Optional[int] = None,
+        norm_cfg: Optional[dict] = None,
+    ) -> None:
+        super().__init__()
+        mid_channels = out_channels if mid_channels is None else mid_channels
+        self.block = torch.nn.Sequential(
+            _ConvBNAct(
+                in_channels,
+                mid_channels,
+                kernel_size=3,
+                padding=1,
+                norm_cfg=norm_cfg,
+            ),
+            _ConvBNAct(
+                mid_channels,
+                out_channels,
+                kernel_size=3,
+                padding=1,
+                norm_cfg=norm_cfg,
+            ),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.block(x)
+
+
+class _Down(torch.nn.Module):
+    """Downsampling block for the U-Net encoder."""
+
+    def __init__(self, in_channels: int, out_channels: int, norm_cfg: Optional[dict]) -> None:
+        super().__init__()
+        self.block = torch.nn.Sequential(
+            torch.nn.MaxPool2d(kernel_size=2),
+            _DoubleConv(in_channels, out_channels, norm_cfg=norm_cfg),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.block(x)
+
+
+class _Up(torch.nn.Module):
+    """Upsampling block for the U-Net decoder."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        bilinear: bool,
+        norm_cfg: Optional[dict],
+    ) -> None:
+        super().__init__()
+        if bilinear:
+            self.up = torch.nn.Upsample(scale_factor=2, mode="bilinear", align_corners=True)
+            mid_channels = in_channels // 2
+            self.conv = _DoubleConv(
+                in_channels,
+                out_channels,
+                mid_channels=mid_channels,
+                norm_cfg=norm_cfg,
+            )
+        else:
+            self.up = torch.nn.ConvTranspose2d(
+                in_channels // 2, in_channels // 2, kernel_size=2, stride=2
+            )
+            self.conv = _DoubleConv(
+                in_channels,
+                out_channels,
+                norm_cfg=norm_cfg,
+            )
+
+    def forward(self, x_high: torch.Tensor, x_skip: torch.Tensor) -> torch.Tensor:
+        x_high = self.up(x_high)
+
+        # Pad if necessary to handle odd input sizes.
+        diff_y = x_skip.size(2) - x_high.size(2)
+        diff_x = x_skip.size(3) - x_high.size(3)
+        if diff_y != 0 or diff_x != 0:
+            x_high = F.pad(
+                x_high,
+                [
+                    diff_x // 2,
+                    diff_x - diff_x // 2,
+                    diff_y // 2,
+                    diff_y - diff_y // 2,
+                ],
+            )
+
+        x = torch.cat([x_skip, x_high], dim=1)
+        return self.conv(x)
+
+
+class _OutConv(torch.nn.Module):
+    """Final 1×1 convolution producing segmentation logits."""
+
+    def __init__(self, in_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(in_channels, out_channels, kernel_size=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
 
 
 class MultiLevelNeck(torch.nn.Module):
@@ -285,6 +400,152 @@ class FCNHead(torch.nn.Module):
         x = self.convs(x)
         x = self.dropout(x)
         return self.classifier(x)
+
+
+class UNet(torch.nn.Module):
+    """U-Net architecture for fully-supervised semantic segmentation.
+
+    The implementation supports either a lightweight PyTorch version defined in
+    this module or a variant backed by ``segmentation-models-pytorch``
+    ("SMP"). The SMP path enables the use of pretrained encoders such as
+    ``resnet34`` or ``resnet50``.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        num_classes: int,
+        base_channels: int = 64,
+        bilinear: bool = True,
+        norm_cfg: Optional[dict] = None,
+        *,
+        encoder_name: Optional[str] = None,
+        encoder_weights: Optional[str] = "imagenet",
+        encoder_depth: int = 5,
+        decoder_channels: Optional[Sequence[int]] = None,
+        decoder_use_batchnorm: bool = True,
+    ) -> None:
+        super().__init__()
+        if norm_cfg is None:
+            norm_cfg = dict(type="BN", eps=1e-5, momentum=0.1)
+
+        self.deepsup = False
+        self.bilinear = bilinear
+        self._encoder_name = encoder_name
+
+        if encoder_name is not None:
+            if smp is None:
+                raise ImportError(
+                    "segmentation-models-pytorch is required for pretrained "
+                    "encoder support. Please install it with "
+                    "`pip install segmentation-models-pytorch`."
+                )
+
+            decoder_kwargs = {}
+            if decoder_channels is not None:
+                decoder_kwargs["decoder_channels"] = tuple(decoder_channels)
+
+            self._smp_model = smp.Unet(
+                encoder_name=encoder_name,
+                encoder_weights=encoder_weights,
+                encoder_depth=encoder_depth,
+                decoder_use_batchnorm=decoder_use_batchnorm,
+                in_channels=in_channels,
+                classes=num_classes,
+                **decoder_kwargs,
+            )
+            self.inc = None
+            self.down1 = None
+            self.down2 = None
+            self.down3 = None
+            self.down4 = None
+            self.up1 = None
+            self.up2 = None
+            self.up3 = None
+            self.up4 = None
+            self.outc = None
+            return
+
+        if base_channels <= 0:
+            raise ValueError("`base_channels` must be a positive integer")
+
+        factor = 2 if bilinear else 1
+
+        self._smp_model = None
+        self.inc = _DoubleConv(in_channels, base_channels, norm_cfg=norm_cfg)
+        self.down1 = _Down(base_channels, base_channels * 2, norm_cfg=norm_cfg)
+        self.down2 = _Down(base_channels * 2, base_channels * 4, norm_cfg=norm_cfg)
+        self.down3 = _Down(base_channels * 4, base_channels * 8, norm_cfg=norm_cfg)
+        self.down4 = _Down(
+            base_channels * 8,
+            base_channels * 16 // factor,
+            norm_cfg=norm_cfg,
+        )
+        self.up1 = _Up(
+            base_channels * 16,
+            base_channels * 8 // factor,
+            bilinear=bilinear,
+            norm_cfg=norm_cfg,
+        )
+        self.up2 = _Up(
+            base_channels * 8,
+            base_channels * 4 // factor,
+            bilinear=bilinear,
+            norm_cfg=norm_cfg,
+        )
+        self.up3 = _Up(
+            base_channels * 4,
+            base_channels * 2 // factor,
+            bilinear=bilinear,
+            norm_cfg=norm_cfg,
+        )
+        self.up4 = _Up(
+            base_channels * 2,
+            base_channels,
+            bilinear=bilinear,
+            norm_cfg=norm_cfg,
+        )
+        self.outc = _OutConv(base_channels, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self._smp_model is not None:
+            return self._smp_model(x)
+
+        x1 = self.inc(x)
+        x2 = self.down1(x1)
+        x3 = self.down2(x2)
+        x4 = self.down3(x3)
+        x5 = self.down4(x4)
+        x = self.up1(x5, x4)
+        x = self.up2(x, x3)
+        x = self.up3(x, x2)
+        x = self.up4(x, x1)
+        return self.outc(x)
+
+    def forward_cd(self, x: torch.Tensor) -> torch.Tensor:
+        """Compute change detection predictions from concatenated inputs."""
+
+        if x.shape[1] % 2 != 0:
+            raise ValueError("Change-detection input must contain an even number of channels")
+
+        mid = x.shape[1] // 2
+        x1 = x[:, :mid]
+        x2 = x[:, mid:]
+        return self.forward(torch.abs(x1 - x2))
+
+    def freeze_encoder(self) -> None:
+        """Freeze encoder parameters when using a pretrained backbone."""
+
+        if self._smp_model is not None:
+            for param in self._smp_model.encoder.parameters():
+                param.requires_grad = False
+            return
+
+        for module in (self.inc, self.down1, self.down2, self.down3, self.down4):
+            if module is None:
+                continue
+            for param in module.parameters():
+                param.requires_grad = False
 
 
 def resize(


### PR DESCRIPTION
## Summary
- extend the UNet implementation to optionally wrap segmentation-models-pytorch for pretrained encoders
- wire the new encoder configuration through the segmentation trainer, main entrypoint, and freeze logic so SMP options flow from configs
- document the configuration knobs for SMP-backed UNet models

## Testing
- python -m compileall src main_segmentation.py

------
https://chatgpt.com/codex/tasks/task_e_68d2ba6b0360832198b05c2361860bb5